### PR TITLE
finish Activity时，取消其所有的Transition效果

### DIFF
--- a/library/src/main/java/me/imid/swipebacklayout/lib/SwipeBackLayout.java
+++ b/library/src/main/java/me/imid/swipebacklayout/lib/SwipeBackLayout.java
@@ -538,8 +538,10 @@ public class SwipeBackLayout extends FrameLayout {
             }
 
             if (mScrollPercent >= 1) {
-                if (!mActivity.isFinishing())
+                if (!mActivity.isFinishing()) {
                     mActivity.finish();
+                    mActivity.overridePendingTransition(0, 0);
+                }
             }
         }
 


### PR DESCRIPTION
finish Activity时，取消其所有的Transition效果。这样处理的原因在于，5.0以上的版本会在Activity已经完全消失时仍然消失多余的动画效果。
