### PR TITLE
 Change the reflecting method of @Activity#convertToTranslucent after Android L

### DIFF
--- a/library/src/main/java/me/imid/swipebacklayout/lib/Utils.java
+++ b/library/src/main/java/me/imid/swipebacklayout/lib/Utils.java
@@ -2,6 +2,8 @@
 package me.imid.swipebacklayout.lib;
 
 import android.app.Activity;
+import android.app.ActivityOptions;
+import android.os.Build;
 
 import java.lang.reflect.Method;
 
@@ -46,6 +48,17 @@ public class Utils {
      * with the {@link android.R.attr#windowIsFloating} attribute.
      */
     public static void convertActivityToTranslucent(Activity activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            convertActivityToTranslucentAfterL(activity);
+        } else {
+            convertActivityToTranslucentBeforeL(activity);
+        }
+    }
+
+    /**
+     * Calling the convertToTranslucent method on platforms before Android 5.0
+     */
+    public static void convertActivityToTranslucentBeforeL(Activity activity) {
         try {
             Class<?>[] classes = Activity.class.getDeclaredClasses();
             Class<?> translucentConversionListenerClazz = null;
@@ -60,6 +73,30 @@ public class Utils {
             method.invoke(activity, new Object[] {
                 null
             });
+        } catch (Throwable t) {
+        }
+    }
+
+    /**
+     * Calling the convertToTranslucent method on platforms after Android 5.0
+     */
+    private static void convertActivityToTranslucentAfterL(Activity activity) {
+        try {
+            Method getActivityOptions = Activity.class.getDeclaredMethod("getActivityOptions");
+            getActivityOptions.setAccessible(true);
+            Object options = getActivityOptions.invoke(activity);
+
+            Class<?>[] classes = Activity.class.getDeclaredClasses();
+            Class<?> translucentConversionListenerClazz = null;
+            for (Class clazz : classes) {
+                if (clazz.getSimpleName().contains("TranslucentConversionListener")) {
+                    translucentConversionListenerClazz = clazz;
+                }
+            }
+            Method convertToTranslucent = Activity.class.getDeclaredMethod("convertToTranslucent",
+                    translucentConversionListenerClazz, ActivityOptions.class);
+            convertToTranslucent.setAccessible(true);
+            convertToTranslucent.invoke(activity, null, options);
         } catch (Throwable t) {
         }
     }


### PR DESCRIPTION
您好。在Android 5.0之后，Activity的convertToTranslucent接口发生改变了，所以我修改了Utils的对convertToTranslucent的反射方法实现，使之对Android 5.0保持兼容。