### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Download
 ===
 Download via Jcenter:
 ```
-compile 'me.imid.swipebacklayout.lib:library:1.1.0'
+implementation 'me.imid.swipebacklayout.lib:library:1.1.0'
 ```
 
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.